### PR TITLE
ci: add vulnerability scanning workflow with govulncheck

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -1,0 +1,34 @@
+name: Vulnerability Scan
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '0 2 1 * *'  # Run at 2 AM on the 1st of every month
+  workflow_dispatch:     # Allow manual triggering
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  vulnerability-scan:
+    runs-on: ubuntu-latest
+    name: Run govulncheck
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Run govulncheck
+        uses: golang/govulncheck-action@v1
+        with:
+          go-package: ./...


### PR DESCRIPTION
- Run govulncheck on push to main and pull requests
- Schedule monthly scans on the 1st at 2 AM
- Support manual workflow dispatch
- Use Go version from go.mod for consistency