### PR TITLE
feat(logger): add compile-time type assertion for Logger interface

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -15,6 +15,9 @@ type Logger interface {
 	Error(msg string, args ...any)
 }
 
+// Compile-time assertion that *slog.Logger implements Logger interface
+var _ Logger = (*slog.Logger)(nil)
+
 // NewLogger creates a new logger
 // logLevel is the level of logging
 // Possible values of logLevel are: "debug", "info", "warn", "error"


### PR DESCRIPTION
- Add compile-time verification that *slog.Logger implements Logger
- Ensures interface compatibility is validated at compile time
- Prevents accidental interface drift during refactoring
- Zero runtime cost, purely compile-time safety improvement

Closes #63