### PR TITLE
fix(logger): add missing period in comment

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -15,7 +15,7 @@ type Logger interface {
 	Error(msg string, args ...any)
 }
 
-// Compile-time assertion that *slog.Logger implements Logger interface
+// Compile-time assertion that *slog.Logger implements Logger interface.
 var _ Logger = (*slog.Logger)(nil)
 
 // NewLogger creates a new logger


### PR DESCRIPTION
Fix linter error by adding period to comment ending