### PR TITLE
chore(deps): bump gitlab-backup image from 1.16.3 to 1.17.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.23.3 AS alpine
 
 FROM ghcr.io/sgaunet/gocrypt:2.0.2 AS gocrypt
 
-FROM ghcr.io/sgaunet/gitlab-backup:1.16.3 AS gitlab-backup-image
+FROM ghcr.io/sgaunet/gitlab-backup:1.17.0 AS gitlab-backup-image
 
 FROM scratch
 LABEL org.opencontainers.image.authors="sgaunet"


### PR DESCRIPTION
Closes #76