### PR TITLE
fix(app): drain stdout/stderr before cmd.Wait

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ You can use the binary but it will need some prerequisites :
 * [gocrypt](https://github.com/sgaunet/gocrypt) >= v2.0.0 (if you like to encrypt archives with AES)
 * [gitlab-backup](https://github.com/sgaunet/gitlab-backup) >= v1.0.0
 
+## Restoring a backup
+
+The [gitlab-backup](https://github.com/sgaunet/gitlab-backup) project also ships a companion binary named **`gitlab-restore`**, which restores a GitLab project backup from the archive produced by `gitlab-backup` back into a GitLab instance. Use it when you need to recover a project from an archive previously stored in S3 by `gitlab-backup2s3` (decrypt it first with `gocrypt` if it was encrypted).
+
 ## Version Compatibility
 
 ⚠️ **Important Breaking Change** ⚠️

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -90,12 +90,13 @@ func (a *App) handleCommandOutput(cmd *exec.Cmd, stderr, stdout io.ReadCloser) e
 	go a.processStderr(stderr, &wg, &stderrErr)
 	go a.processStdout(stdout, &wg, &stdoutErr)
 
+	// Wait for output readers to finish before cmd.Wait, which closes the pipes.
+	wg.Wait()
+
 	err := cmd.Wait()
 	if err != nil {
 		return fmt.Errorf("error waiting for command: %w", err)
 	}
-
-	wg.Wait()
 
 	if stderrErr != nil {
 		return stderrErr


### PR DESCRIPTION
cmd.Wait closes the subprocess pipes the moment the child exits, so
the scanner goroutines could lose their last read and surface as
"read |0: file already closed" — observed intermittently in CI on
TestSetLoggerNil. Wait on the goroutines first, then on the command.

Closes #92